### PR TITLE
Pass `contentId` to `onGetLicense`

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -234,7 +234,7 @@ export default class Video extends Component {
     if (this.props.drm && this.props.drm.getLicense instanceof Function) {
       const data = event.nativeEvent;
       if (data && data.spc) {
-        const getLicenseOverride = this.props.drm.getLicense(data.spc, this.props);
+        const getLicenseOverride = this.props.drm.getLicense(data.spc, this.props, data.contentId);
         const getLicensePromise = Promise.resolve(getLicenseOverride); // Handles both scenarios, getLicenseOverride being a promise and not.
         getLicensePromise.then((result => {
           if (result !== undefined) {

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -1736,6 +1736,7 @@ didCancelLoadingRequest:(AVAssetResourceLoadingRequest *)loadingRequest {
                   NSString *spcStr = [[NSString alloc] initWithData:spcData encoding:NSASCIIStringEncoding];
                   self->_requestingCertificate = YES;
                   self.onGetLicense(@{@"spc": spcStr,
+                                      @"contentId": contentId,
                                       @"target": self.reactTag});
                 } else if(licenseServer != nil) {
                   NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];


### PR DESCRIPTION
Some DRM providers require `contentID` for the license request.

Example for [BuyDRM](https://www.buydrm.com/) https://github.com/yurtaev/react-native-video/blob/example%2FDRM/storybook/stories/DRMExample/index.ios.js#L20

```js
const getLicense = async ({ spcBase64, contentId }, props) => {
  const {
    drm: { headers },
  } = props

  const data = `spc=${spcBase64}&assetId=${contentId}`

  const response = await fetch('https://fp-keyos.licensekeyserver.com/getkey/', {
    method: 'POST',
    headers,
    body: data,
  })

  const key = await response.text()
  return key
}
```