### PR TITLE
Pass spcBase64 to getLicense

### DIFF
--- a/DRM.md
+++ b/DRM.md
@@ -37,10 +37,9 @@ Platforms: iOS
 With this prop you can override the license acquisition flow, as an example:
 
 ```js
-getLicense: (spcString) => {
-  const base64spc = Base64.encode(spcString);
+getLicense: ({ spcString, spcBase64 }, props) => {
   const formData = new FormData();
-  formData.append('spc', base64spc);
+  formData.append('spc', spcBase64);
   return fetch(`https://license.pallycon.com/ri/licenseManager.do`, {
       method: 'POST',
       headers: {
@@ -108,8 +107,7 @@ drm: {
 ```js
 drm: {
     type: DRMType.FAIRPLAY,
-    getLicense: (spcString) => {
-        const base64spc = Base64.encode(spcString);
+    getLicense: ({ spcString, spcBase64 }, props) => {
         return fetch('YOUR LICENSE SERVER HERE', {
             method: 'POST',
             headers: {
@@ -119,7 +117,7 @@ drm: {
             body: JSON.stringify({
                 getFairplayLicense: {
                     foo: 'bar',
-                    spcMessage: base64spc,
+                    spcMessage: spcBase64,
                 }
             })
         })

--- a/Video.js
+++ b/Video.js
@@ -233,8 +233,8 @@ export default class Video extends Component {
   _onGetLicense = (event) => {
     if (this.props.drm && this.props.drm.getLicense instanceof Function) {
       const data = event.nativeEvent;
-      if (data && data.spc) {
-        const getLicenseOverride = this.props.drm.getLicense(data.spc, this.props);
+      if (data && data.spcBase64) {
+        const getLicenseOverride = this.props.drm.getLicense(data, this.props);
         const getLicensePromise = Promise.resolve(getLicenseOverride); // Handles both scenarios, getLicenseOverride being a promise and not.
         getLicensePromise.then((result => {
           if (result !== undefined) {

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -1735,7 +1735,8 @@ didCancelLoadingRequest:(AVAssetResourceLoadingRequest *)loadingRequest {
                 if(self.onGetLicense) {
                   NSString *spcStr = [[NSString alloc] initWithData:spcData encoding:NSASCIIStringEncoding];
                   self->_requestingCertificate = YES;
-                  self.onGetLicense(@{@"spc": spcStr,
+                  self.onGetLicense(@{@"spcString": spcStr,
+                                      @"spcBase64": [spcData base64EncodedStringWithOptions:0],
                                       @"target": self.reactTag});
                 } else if(licenseServer != nil) {
                   NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];


### PR DESCRIPTION
I don't know why but `spcString` is empty (on js side) if app running not in debug mode. 

I think different behavior (unicode strings?) between JavaScriptCore & V8/Chrome (debug mode) is causing this.

Any ideas?

Demo: https://github.com/yurtaev/react-native-video/blob/example%2FDRM/storybook/stories/DRMExample/index.ios.js#L20