### PR TITLE
Fixes crash in iOS 13.6 iPhone 11

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -703,9 +703,15 @@ static int const RCTVideoUnset = -1;
 
         if (!CGRectEqualToRect(oldRect, newRect)) {
           if (CGRectEqualToRect(newRect, [UIScreen mainScreen].bounds)) {
-            NSLog(@"in fullscreen");
-            if (!_fullscreenPlayerPresented && _controls) {
-              _fullscreenPlayerPresented = YES;
+            bool shouldFire = !_fullscreenPlayerPresented;
+
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (shouldFire) {
+                  _fullscreenPlayerPresented = YES;
+                }
+            });
+
+            if (shouldFire) {
               if(self.onVideoFullscreenPlayerWillPresent) {
                 self.onVideoFullscreenPlayerWillPresent(@{@"target": self.reactTag});
               }
@@ -714,9 +720,15 @@ static int const RCTVideoUnset = -1;
               }
             }
           } else {
-            NSLog(@"not fullscreen");
-            if (_fullscreenPlayerPresented && _controls) {
-              _fullscreenPlayerPresented = NO;
+            bool shouldFire = _fullscreenPlayerPresented;
+
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (shouldFire) {
+                  _fullscreenPlayerPresented = NO;
+                }
+            });
+
+            if (shouldFire) {
               if(self.onVideoFullscreenPlayerWillDismiss) {
                 self.onVideoFullscreenPlayerWillDismiss(@{@"target": self.reactTag});
               }


### PR DESCRIPTION
This fixes the crash that happens in iPhone11 (iOS 13.6), tested in iOS Simulator. 

When you go to fullscreen, video freezes after a bit. Trying to exit fullscreen crashes with an error. This fixes it.

Also tested in iPhone 6 and iPhone 7 (iOS 12.4) in Simulator, works fine there as well.